### PR TITLE
Updated includes and booleans to latest available

### DIFF
--- a/blackbody.py
+++ b/blackbody.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import scipy.misc as spm
+import imageio
 
 #accretion disk log temperature profile (R^{-3/4})
 LOGSHIFT = 0.823959216501 # 3/4 log(3)
@@ -25,7 +26,7 @@ def intensity(T):
     return 1./( np.exp(29622.4 / T.clip(1.)) - 1)
 
 
-ramp = spm.imread('data/colourtemp.jpg')[0,:,:]/255.
+ramp = imageio.imread('data/colourtemp.jpg')[0,:,:]/255.
 rampsz = ramp.shape[0]
 
 

--- a/tracer.py
+++ b/tracer.py
@@ -6,6 +6,8 @@ import scipy.ndimage as ndim
 import scipy.misc as spm
 import random,sys,time,os
 import datetime
+import imageio
+from PIL import Image
 
 import multiprocessing as multi
 import ctypes
@@ -313,7 +315,7 @@ def rgbtosrgb(arr):
     arr[mask] **= 1/2.4
     arr[mask] *= 1.055
     arr[mask] -= 0.055
-    arr[-mask] *= 12.92
+    arr[~mask] *= 12.92
 
 
 # convert from srgb to linear rgb
@@ -323,31 +325,33 @@ def srgbtorgb(arr):
     arr[mask] += 0.055
     arr[mask] /= 1.055
     arr[mask] **= 2.4
-    arr[-mask] /= 12.92
+    arr[~mask] /= 12.92
 
 
 logger.debug("Loading textures...")
 if SKY_TEXTURE == 'texture':
-    texarr_sky = spm.imread('textures/bgedit.jpg')
+    texarr_sky = imageio.imread('textures/bgedit.jpg')
+    texarr_test = imageio.imread('textures/bgedit.jpg')
     # must convert to float here so we can work in linear colour
     texarr_sky = texarr_sky.astype(float)
     texarr_sky /= 255.0
     if SRGBIN:
         # must do this before resizing to get correct results
         srgbtorgb(texarr_sky)
-    if not LOFI:
+    #if not LOFI:
         #   maybe doing this manually and then loading is better.
-        logger.debug("(zooming sky texture...)")
-        texarr_sky = spm.imresize(texarr_sky,2.0,interp='bicubic')
+        # logger.debug("(zooming sky texture...)")
+        # newsize = (640,480)
+        # texarr_sky = texarr_sky.resize(newsize)
         # imresize converts back to uint8 for whatever reason
-        texarr_sky = texarr_sky.astype(float)
-        texarr_sky /= 255.0
+        # texarr_sky = texarr_sky.astype(float)
+        # texarr_sky /= 255.0
 
 texarr_disk = None
 if DISK_TEXTURE == 'texture':
-    texarr_disk = spm.imread('textures/adisk.jpg')
+    texarr_disk = imageio.imread('textures/adisk.jpg')
 if DISK_TEXTURE == 'test':
-    texarr_disk = spm.imread('textures/adisktest.jpg')
+    texarr_disk = imageio.imread('textures/adisktest.jpg')
 if texarr_disk is not None:
     # must convert to float here so we can work in linear colour
     texarr_disk = texarr_disk.astype(float)


### PR DESCRIPTION
Some of the includes were deprecated, and the boolean "-" was apparently changed to "~" in the latest Python3.  I revised accordingly.  I also dropped a problematic section on resizing the background image due to conflicts with the imageio library.  So the background doesn't get resized properly, but otherwise it works and looks great; I'm sure a more professional programmer could resolve that quickly, but I'm just a hobbyist.  Thanks to the authors for their hard work.  There is no other way to accurately visualize a black hole without paying huge amounts of money to a visual effects studio.